### PR TITLE
add custom metrics

### DIFF
--- a/conf/biencoder_train_cfg.yaml
+++ b/conf/biencoder_train_cfg.yaml
@@ -48,4 +48,4 @@ ignore_checkpoint_optimizer: False
 multi_q_encoder: False
 
 # report logs to W&B
-wandb_logs: True
+wandb_logs: False

--- a/conf/biencoder_train_cfg.yaml
+++ b/conf/biencoder_train_cfg.yaml
@@ -46,3 +46,6 @@ ignore_checkpoint_optimizer: False
 
 # set to >1 to enable multiple query encoders
 multi_q_encoder: False
+
+# report logs to W&B
+wandb_logs: True

--- a/conf/biencoder_train_cfg.yaml
+++ b/conf/biencoder_train_cfg.yaml
@@ -7,6 +7,7 @@ defaults:
 
 train_datasets:
 dev_datasets:
+customer_chunks:
 output_dir:
 train_sampling_rates:
 loss_scale_factors:

--- a/conf/train/biencoder_default.yaml
+++ b/conf/train/biencoder_default.yaml
@@ -25,3 +25,4 @@ val_av_rank_hard_neg: 30
 val_av_rank_other_neg: 30
 val_av_rank_bsz: 128
 val_av_rank_max_qs: 10000
+eval_during_epoch: False

--- a/conf/train/biencoder_default.yaml
+++ b/conf/train/biencoder_default.yaml
@@ -26,3 +26,4 @@ val_av_rank_other_neg: 30
 val_av_rank_bsz: 128
 val_av_rank_max_qs: 10000
 eval_during_epoch: False
+higher_is_better: False

--- a/conf/train/biencoder_default.yaml
+++ b/conf/train/biencoder_default.yaml
@@ -27,3 +27,6 @@ val_av_rank_bsz: 128
 val_av_rank_max_qs: 10000
 eval_during_epoch: False
 higher_is_better: False
+
+# save separate models at the end of each epoch
+save_separate_models: False

--- a/conf/train/biencoder_local.yaml
+++ b/conf/train/biencoder_local.yaml
@@ -31,3 +31,6 @@ higher_is_better: True
 
 # save separate models at the end of each epoch
 save_separate_models: False
+
+# if true, saves only best model
+save_best_only: True

--- a/conf/train/biencoder_local.yaml
+++ b/conf/train/biencoder_local.yaml
@@ -17,7 +17,7 @@ warmup_steps: 0
 gradient_accumulation_steps: 1
 
 # Total number of training epochs to perform.
-num_train_epochs: 20
+num_train_epochs: 40
 eval_per_epoch: 1
 hard_negatives: 1
 other_negatives: 0
@@ -27,3 +27,4 @@ val_av_rank_bsz: 128
 val_av_rank_max_qs: 10000
 top_k: 1000
 eval_during_epoch: False
+higher_is_better: True

--- a/conf/train/biencoder_local.yaml
+++ b/conf/train/biencoder_local.yaml
@@ -28,3 +28,6 @@ val_av_rank_max_qs: 10000
 top_k: 1000
 eval_during_epoch: False
 higher_is_better: True
+
+# save separate models at the end of each epoch
+save_separate_models: False

--- a/conf/train/biencoder_local.yaml
+++ b/conf/train/biencoder_local.yaml
@@ -25,3 +25,4 @@ val_av_rank_hard_neg: 30
 val_av_rank_other_neg: 30
 val_av_rank_bsz: 128
 val_av_rank_max_qs: 10000
+top_k: 1000

--- a/conf/train/biencoder_local.yaml
+++ b/conf/train/biencoder_local.yaml
@@ -26,3 +26,4 @@ val_av_rank_other_neg: 30
 val_av_rank_bsz: 128
 val_av_rank_max_qs: 10000
 top_k: 1000
+eval_during_epoch: False

--- a/conf/train/biencoder_nq.yaml
+++ b/conf/train/biencoder_nq.yaml
@@ -25,3 +25,4 @@ val_av_rank_hard_neg: 30
 val_av_rank_other_neg: 30
 val_av_rank_bsz: 128
 val_av_rank_max_qs: 10000
+eval_during_epoch: True

--- a/conf/train/biencoder_nq.yaml
+++ b/conf/train/biencoder_nq.yaml
@@ -26,3 +26,4 @@ val_av_rank_other_neg: 30
 val_av_rank_bsz: 128
 val_av_rank_max_qs: 10000
 eval_during_epoch: True
+higher_is_better: False

--- a/conf/train/biencoder_nq.yaml
+++ b/conf/train/biencoder_nq.yaml
@@ -27,3 +27,6 @@ val_av_rank_bsz: 128
 val_av_rank_max_qs: 10000
 eval_during_epoch: True
 higher_is_better: False
+
+# save separate models at the end of each epoch
+save_separate_models: False

--- a/dpr/data/biencoder_data.py
+++ b/dpr/data/biencoder_data.py
@@ -4,7 +4,8 @@ import glob
 import logging
 import os
 import random
-from typing import Dict, List, Tuple
+from dataclasses import dataclass
+from typing import Dict, List, Tuple, Optional
 
 import hydra
 import jsonlines
@@ -17,7 +18,16 @@ from dpr.data.tables import Table
 from dpr.utils.data_utils import read_data_from_json_files, Tensorizer
 
 logger = logging.getLogger(__name__)
-BiEncoderPassage = collections.namedtuple("BiEncoderPassage", ["text", "title"])
+
+
+@dataclass
+class BiEncoderPassage:
+    text: str
+    title: str
+    url: Optional[str] = None
+    chunk_index: Optional[int] = None
+    chunk_meta: Optional[Dict] = None
+    customer_name: Optional[str] = None
 
 
 class BiEncoderSample(object):
@@ -163,8 +173,12 @@ class JsonQADataset(Dataset):
 
         def create_passage(ctx: dict):
             return BiEncoderPassage(
-                normalize_passage(ctx["text"]) if self.normalize else ctx["text"],
-                ctx["title"],
+                text=normalize_passage(ctx["text"]) if self.normalize else ctx["text"],
+                title=ctx["title"],
+                url=ctx["url"] if "url" in ctx else None,
+                chunk_index=ctx["chunk_index"] if "chunk_index" in ctx else None,
+                chunk_meta=ctx["chunk_meta"] if "chunk_meta" in ctx else None,
+                customer_name=ctx["customer_name"] if "customer_name" in ctx else None,
             )
 
         r.positive_passages = [create_passage(ctx) for ctx in positive_ctxs]

--- a/dpr/data/download_data.py
+++ b/dpr/data/download_data.py
@@ -395,6 +395,13 @@ RESOURCES_MAP = {
         "desc": "AskAI DPR training set",
         "license_files": NQ_LICENSE_FILES,
     },
+    "data.retriever.ask-ai-dpr-chunks": {
+        "s3_url": "https://ask-ai-dev.s3.us-east-2.amazonaws.com/training/data/dpr_training_data_yotpo_support_110[…]2_185614_annotations_dpr_annotations_train.json.gzip",
+        "original_ext": ".json",
+        "compressed": True,
+        "desc": "AskAI DPR customer chunks",
+        "license_files": NQ_LICENSE_FILES,
+    },
 }
 
 

--- a/dpr/metrics/data_classes.py
+++ b/dpr/metrics/data_classes.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
+
+
+@dataclass
+class HitAtRanks:
+    rank_to_hit: Dict[int, Union[int, float]]
+
+
+@dataclass
+class PrecisionAtRankMetrics:
+    precision: float
+    url: int
+    section: int
+
+
+@dataclass
+class IRMetrics:
+    rank_to_p_metrics: Dict[int, PrecisionAtRankMetrics]
+    section_hit_scores_rank: Optional[int] = None
+    article_hit_scores_rank: Optional[int] = None

--- a/dpr/metrics/retriever_metrics_utils.py
+++ b/dpr/metrics/retriever_metrics_utils.py
@@ -1,0 +1,96 @@
+from typing import List, Set
+
+import numpy as np
+
+from dpr.data.biencoder_data import BiEncoderPassage
+from dpr.metrics.data_classes import IRMetrics, PrecisionAtRankMetrics, HitAtRanks
+
+
+def get_hit_at_scores(hit_rank: int) -> HitAtRanks:
+    """
+    returns hit@2,5,30 given the list of scores at every index
+    """
+    if hit_rank is None:
+        return HitAtRanks(rank_to_hit={1: 0, 2: 0, 5: 0, 30: 0})
+    hit_at1 = 1 if hit_rank < 1 else 0
+    hit_at2 = 1 if hit_rank < 2 else 0
+    hit_at5 = 1 if hit_rank < 5 else 0
+    hit_at30 = 1 if hit_rank < 30 else 0
+    return HitAtRanks(rank_to_hit={1: hit_at1, 2: hit_at2, 5: hit_at5, 30: hit_at30})
+
+
+def merge_chunk_and_url_scores(chunk_score: int, url_score: int) -> float:
+    """
+    merge between the chunk level and url level scores to get one metric
+    we give the url strength of 0.5 that of the chunks
+    """
+    if chunk_score > 0:
+        return chunk_score
+    else:
+        return url_score * 0.5
+
+
+def merge_chunks_url_scores(chunks_scores: HitAtRanks, article_scores: HitAtRanks) -> HitAtRanks:
+    p1 = merge_chunk_and_url_scores(chunks_scores.rank_to_hit[1], article_scores.rank_to_hit[1])
+    p2 = merge_chunk_and_url_scores(chunks_scores.rank_to_hit[2], article_scores.rank_to_hit[2])
+    p5 = merge_chunk_and_url_scores(chunks_scores.rank_to_hit[5], article_scores.rank_to_hit[5])
+    p30 = merge_chunk_and_url_scores(chunks_scores.rank_to_hit[30], article_scores.rank_to_hit[30])
+
+    return HitAtRanks(rank_to_hit={1: p1, 2: p2, 5: p5, 30: p30})
+
+
+def get_url_no_anchor(chunk_url):
+    return chunk_url.split("#")[0]
+
+
+def calculate_ir_scores(
+    gold_passages: List[BiEncoderPassage],
+    predicted_passages: List[BiEncoderPassage]
+) -> IRMetrics:
+    gold_sections: Set[int] = {passage.chunk_index for passage in gold_passages}
+
+    section_hit_scores = [
+        1 if pred.chunk_index in gold_sections else 0
+        for pred in predicted_passages
+    ]
+
+    gold_article_urls: Set[set] = {get_url_no_anchor(passage.url) for passage in gold_passages}
+
+    article_hit_scores = [
+        1 if get_url_no_anchor(pred.url) in gold_article_urls else 0
+        for pred in predicted_passages
+    ]
+
+    section_hit_scores_rank, article_hit_scores_rank = None, None
+    section_hit_scores_argmax = np.argmax(section_hit_scores)
+    article_hit_scores_argmax = np.argmax(article_hit_scores)
+
+    if section_hit_scores[section_hit_scores_argmax] == 1:
+        section_hit_scores_rank = int(section_hit_scores_argmax)
+    if article_hit_scores[article_hit_scores_argmax] == 1:
+        article_hit_scores_rank = int(article_hit_scores_argmax)
+
+    article_hits: HitAtRanks = get_hit_at_scores(article_hit_scores_rank)
+    sections_hits: HitAtRanks = get_hit_at_scores(section_hit_scores_rank)
+    p_at_ranks: HitAtRanks = merge_chunks_url_scores(chunks_scores=sections_hits, article_scores=article_hits)
+
+    ir_metrics: IRMetrics = IRMetrics(
+        rank_to_p_metrics={
+            1: PrecisionAtRankMetrics(
+                p_at_ranks.rank_to_hit[1], url=article_hits.rank_to_hit[1], section=sections_hits.rank_to_hit[1]
+            ),
+            2: PrecisionAtRankMetrics(
+                p_at_ranks.rank_to_hit[2], url=article_hits.rank_to_hit[2], section=sections_hits.rank_to_hit[2]
+            ),
+            5: PrecisionAtRankMetrics(
+                p_at_ranks.rank_to_hit[5], url=article_hits.rank_to_hit[5], section=sections_hits.rank_to_hit[5]
+            ),
+            30: PrecisionAtRankMetrics(
+                p_at_ranks.rank_to_hit[30], url=article_hits.rank_to_hit[30], section=sections_hits.rank_to_hit[30]
+            ),
+        },
+        section_hit_scores_rank=section_hit_scores_rank,
+        article_hit_scores_rank=article_hit_scores_rank,
+    )
+
+    return ir_metrics

--- a/dpr/models/hf_models.py
+++ b/dpr/models/hf_models.py
@@ -10,6 +10,7 @@ Encoder model wrappers based on HuggingFace code
 """
 
 import logging
+import os
 from typing import Tuple
 
 import torch
@@ -220,6 +221,14 @@ class HFBertEncoder(BertModel):
         if self.encode_proj:
             return self.encode_proj.out_features
         return self.config.hidden_size
+
+    def save(self, output_dir: str):
+        # If we are executing this function, we are the process zero, so we don't check for that.
+        os.makedirs(output_dir, exist_ok=True)
+        logger.info(f"Saving model checkpoint to {output_dir}")
+        # Save a trained model and configuration using `save_pretrained()`.
+        # They can then be reloaded using `from_pretrained()`
+        self.save_pretrained(output_dir)
 
 
 class BertTensorizer(Tensorizer):

--- a/dpr/utils/data_utils.py
+++ b/dpr/utils/data_utils.py
@@ -17,7 +17,7 @@ import itertools
 import math
 import torch
 from torch import Tensor as T
-from typing import List, Iterator, Callable, Tuple
+from typing import List, Iterator, Callable, Tuple, Dict
 
 logger = logging.getLogger()
 
@@ -34,7 +34,7 @@ def read_serialized_data_from_files(paths: List[str]) -> List:
     return results
 
 
-def read_data_from_json_files(paths: List[str]) -> List:
+def read_data_from_json_files(paths: List[str]) -> Dict:
     results = []
     for i, path in enumerate(paths):
         with open(path, "r", encoding="utf-8") as f:

--- a/generate_dense_embeddings.py
+++ b/generate_dense_embeddings.py
@@ -79,8 +79,6 @@ def gen_ctx_vectors(
         else:
             results.extend([(ctx_ids[i], out[i].view(-1).numpy()) for i in range(out.size(0))])
 
-        if total % 100 == 0:
-            logger.info("Encoded passages %d out of %d", total, n)
     return results
 
 

--- a/generate_dense_embeddings.py
+++ b/generate_dense_embeddings.py
@@ -21,6 +21,7 @@ import numpy as np
 import torch
 from omegaconf import DictConfig, OmegaConf
 from torch import nn
+from tqdm import tqdm
 
 from dpr.data.biencoder_data import BiEncoderPassage
 from dpr.models import init_biencoder_components
@@ -39,25 +40,27 @@ setup_logger(logger)
 
 
 def gen_ctx_vectors(
-    cfg: DictConfig,
+    batch_size: int,
+    device: str,
     ctx_rows: List[Tuple[object, BiEncoderPassage]],
     model: nn.Module,
     tensorizer: Tensorizer,
     insert_title: bool = True,
 ) -> List[Tuple[object, np.array]]:
     n = len(ctx_rows)
-    bsz = cfg.batch_size
+    bsz = batch_size
     total = 0
     results = []
-    for j, batch_start in enumerate(range(0, n, bsz)):
+    logger.info("Encoding passages...")
+    for j, batch_start in tqdm(enumerate(range(0, n, bsz)), total=n // bsz):
         batch = ctx_rows[batch_start : batch_start + bsz]
         batch_token_tensors = [
             tensorizer.text_to_tensor(ctx[1].text, title=ctx[1].title if insert_title else None) for ctx in batch
         ]
 
-        ctx_ids_batch = move_to_device(torch.stack(batch_token_tensors, dim=0), cfg.device)
-        ctx_seg_batch = move_to_device(torch.zeros_like(ctx_ids_batch), cfg.device)
-        ctx_attn_mask = move_to_device(tensorizer.get_attn_mask(ctx_ids_batch), cfg.device)
+        ctx_ids_batch = move_to_device(torch.stack(batch_token_tensors, dim=0), device)
+        ctx_seg_batch = move_to_device(torch.zeros_like(ctx_ids_batch), device)
+        ctx_attn_mask = move_to_device(tensorizer.get_attn_mask(ctx_ids_batch), device)
         with torch.no_grad():
             _, out, _ = model(ctx_ids_batch, ctx_seg_batch, ctx_attn_mask)
         out = out.cpu()
@@ -76,8 +79,8 @@ def gen_ctx_vectors(
         else:
             results.extend([(ctx_ids[i], out[i].view(-1).numpy()) for i in range(out.size(0))])
 
-        if total % 10 == 0:
-            logger.info("Encoded passages %d", total)
+        if total % 100 == 0:
+            logger.info("Encoded passages %d out of %d", total, n)
     return results
 
 
@@ -140,7 +143,7 @@ def main(cfg: DictConfig):
     )
     shard_passages = all_passages[start_idx:end_idx]
 
-    data = gen_ctx_vectors(cfg, shard_passages, encoder, tensorizer, True)
+    data = gen_ctx_vectors(cfg.batch_size, cfg.device, shard_passages, encoder, tensorizer, True)
 
     file = cfg.out_file + "_" + str(cfg.shard_id)
     pathlib.Path(os.path.dirname(file)).mkdir(parents=True, exist_ok=True)

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "filelock",
         "numpy",
         "regex",
+        "pandas",
         "torch>=1.5.0",
         "transformers>=3.0.0,<3.1.0",
         "tqdm>=4.27",

--- a/train_dense_encoder.py
+++ b/train_dense_encoder.py
@@ -321,7 +321,7 @@ class BiEncoderTrainer(object):
         for i, samples_batch in enumerate(data_iterator.iterate_ds_data()):
             if isinstance(samples_batch, Tuple):
                 samples_batch, dataset = samples_batch
-            logger.info("Eval step: %d ,rnk=%s", i, cfg.local_rank)
+
             biencoder_input = BiEncoder.create_biencoder_input2(
                 samples_batch,
                 self.tensorizer,

--- a/train_dense_encoder.py
+++ b/train_dense_encoder.py
@@ -394,7 +394,7 @@ class BiEncoderTrainer(object):
             retrieved_passages_ids = [
                 passage_index_to_passage_id[passage_index] for passage_index in retrieved_passage_indices
             ]
-            retrieved_passages = [passage_id_to_passage[passage_id][1] for passage_id in retrieved_passages_ids]
+            retrieved_passages = [passage_id_to_passage[passage_id] for passage_id in retrieved_passages_ids]
             sample_ir_metrics: IRMetrics = calculate_ir_scores(sample.positive_passages, retrieved_passages)
 
             if_metrics_dict = {

--- a/train_dense_encoder.py
+++ b/train_dense_encoder.py
@@ -762,6 +762,9 @@ class BiEncoderTrainer(object):
         else:
             cp = os.path.join(cfg.output_dir, cfg.checkpoint_file_name + "_best.cp")
 
+        # save tokenizer
+        self.tensorizer.tokenizer.save_pretrained(cfg.output_dir)
+
         meta_params = get_encoder_params_state_from_cfg(cfg)
         state = CheckpointState(
             model_to_save.get_state_dict(),

--- a/train_dense_encoder.py
+++ b/train_dense_encoder.py
@@ -17,15 +17,20 @@ import random
 import sys
 import time
 from datetime import datetime
-from typing import Tuple, Dict
+from typing import Tuple, Dict, List
 
 import hydra
+import numpy as np
 import torch
 import wandb
 from omegaconf import DictConfig, OmegaConf
 from torch import Tensor as T
 from torch import nn
+import pandas as pd
 
+from dpr.data.biencoder_data import get_dpr_files, BiEncoderPassage, BiEncoderSample
+from dpr.metrics.data_classes import IRMetrics
+from dpr.metrics.retriever_metrics_utils import calculate_ir_scores
 from dpr.models import init_biencoder_components
 from dpr.models.biencoder import BiEncoder, BiEncoderNllLoss, BiEncoderBatch
 from dpr.options import (
@@ -40,6 +45,7 @@ from dpr.utils.data_utils import (
     ShardedDataIterator,
     Tensorizer,
     MultiSetDataIterator,
+    read_data_from_json_files,
 )
 from dpr.utils.dist_utils import all_gather_list
 from dpr.utils.model_utils import (
@@ -51,6 +57,7 @@ from dpr.utils.model_utils import (
     get_model_obj,
     load_states_from_checkpoint,
 )
+from generate_dense_embeddings import gen_ctx_vectors
 
 logger = logging.getLogger()
 setup_logger(logger)
@@ -165,6 +172,28 @@ class BiEncoderTrainer(object):
     def run_train(self):
         cfg = self.cfg
 
+        all_passages: List[Tuple[object, BiEncoderPassage]] = []
+        if cfg.customer_chunks:
+            logger.info(f"Reading customer chunks from {cfg.customer_chunks}")
+            customer_chunks_file_paths = get_dpr_files(cfg.customer_chunks)
+            if not customer_chunks_file_paths:
+                raise ValueError(f"File descriptor {cfg.customer_chunks} is not configured.")
+            customer_chunks = read_data_from_json_files(customer_chunks_file_paths)
+
+            logger.info("Converting customer chunks to BiEncoderPassage objects")
+            if customer_chunks:
+                for customer_name, chunks in customer_chunks.items():
+                    all_passages.extend([
+                        (chunk["chunk_index"], BiEncoderPassage(
+                            text=chunk["chunk"],
+                            title=chunk["title"],
+                            url=chunk["url"],
+                            chunk_index=chunk["chunk_index"],
+                            chunk_meta=chunk["meta"],
+                            customer_name=customer_name
+                        )) for chunk in chunks.values()
+                    ])
+
         train_iterator = self.get_data_iterator(
             cfg.train.batch_size,
             True,
@@ -208,13 +237,20 @@ class BiEncoderTrainer(object):
 
         for epoch in range(self.start_epoch, int(cfg.train.num_train_epochs)):
             logger.info("***** Epoch %d *****", epoch)
-            epoch_metrics: Dict[str, float] = self._train_epoch(scheduler, epoch, eval_step, train_iterator)
+            epoch_metrics: Dict[str, float] = self._train_epoch(scheduler, epoch, eval_step, train_iterator, all_passages)
             wandb.log(epoch_metrics)
 
         if cfg.local_rank in [-1, 0]:
             logger.info("Training finished. Best validation checkpoint %s", self.best_cp_name)
 
-    def validate_and_save(self, epoch: int, iteration: int, scheduler, save: bool = True) -> Dict[str, float]:
+    def validate_and_save(
+        self,
+        epoch: int,
+        iteration: int,
+        scheduler,
+        all_passages: List[Tuple[object, BiEncoderPassage]],
+        save: bool = True,
+    ) -> Dict[str, float]:
         metrics: Dict[str, float] = {}
 
         cfg = self.cfg
@@ -227,7 +263,10 @@ class BiEncoderTrainer(object):
         if not cfg.dev_datasets:
             validation_loss = 0
         else:
-            metrics = self.validate_nll()
+            # metrics = self.validate_nll()
+            if all_passages:
+                ask_ai_ir_metrics = self.validate_ask_ai_metrics(all_passages)
+                metrics.update(ask_ai_ir_metrics)
             average_rank_loss = self.validate_average_rank()
             metrics["Dev Average Rank"] = average_rank_loss
 
@@ -325,6 +364,55 @@ class BiEncoderTrainer(object):
 
         return metrics
 
+    def validate_ask_ai_metrics(self, all_passages: List[Tuple[object, BiEncoderPassage]]) -> Dict:
+        logger.info("AskAI IR metrics")
+
+        encoded_passages_and_ids: List[Tuple[object, np.array]] = self._encode_all_passages(all_passages[0:100])
+        encoded_passages = torch.tensor([passage[1] for passage in encoded_passages_and_ids])
+
+        q_represenations, _, positive_idx_per_question, all_samples = self._encode_questions_and_passages(
+            without_negatives=True, return_samples=True,
+        )
+
+        logger.info("AskAI IR validation: total q_vectors size=%s", q_represenations.size())
+        logger.info("AskAI IR validation: total ctx_vectors size=%s", encoded_passages.size())
+
+        # compute similarity score between all questions to all passages
+        sim_score_f = BiEncoderNllLoss.get_similarity_function()
+        scores = sim_score_f(q_represenations, encoded_passages)
+        values, indices = torch.sort(scores, dim=1, descending=True)
+
+        ir_metrics: List[Dict] = []
+        for index, sample in enumerate(all_samples):
+            # for each question, get top k passages using their indices
+            retrieved_passage_indices = indices[index][0:self.cfg.train.top_k]
+            retrieved_passages = [all_passages[passage_index][1] for passage_index in retrieved_passage_indices]
+            sample_ir_metrics: IRMetrics = calculate_ir_scores(sample.positive_passages, retrieved_passages)
+
+            if_metrics_dict = {
+                "p@1": sample_ir_metrics.rank_to_p_metrics[1].precision,
+                "p@2": sample_ir_metrics.rank_to_p_metrics[2].precision,
+                "p@5": sample_ir_metrics.rank_to_p_metrics[5].precision,
+                "p@30": sample_ir_metrics.rank_to_p_metrics[30].precision,
+                "url_rank": sample_ir_metrics.article_hit_scores_rank,
+                "section_rank": sample_ir_metrics.section_hit_scores_rank,
+                "p1_Url": sample_ir_metrics.rank_to_p_metrics[1].url,
+                "p2_Url": sample_ir_metrics.rank_to_p_metrics[2].url,
+                "p5_Url": sample_ir_metrics.rank_to_p_metrics[5].url,
+                "p30_Url": sample_ir_metrics.rank_to_p_metrics[30].url,
+                "p1_Section": sample_ir_metrics.rank_to_p_metrics[1].section,
+                "p2_Section": sample_ir_metrics.rank_to_p_metrics[2].section,
+                "p5_Section": sample_ir_metrics.rank_to_p_metrics[5].section,
+                "p30_Section": sample_ir_metrics.rank_to_p_metrics[30].section,
+            }
+
+            ir_metrics.append(if_metrics_dict)
+
+        all_preds_df = pd.DataFrame(ir_metrics)
+        preds_df = (all_preds_df.mean() * 100).round(1)
+
+        return preds_df.to_dict()
+
     def validate_average_rank(self) -> float:
         """
         Validates biencoder model using each question's gold passage's rank across the set of passages from the dataset.
@@ -337,34 +425,85 @@ class BiEncoderTrainer(object):
         """
         logger.info("Average rank validation ...")
 
-        cfg = self.cfg
         self.biencoder.eval()
-        distributed_factor = self.distributed_factor
+
+        q_represenations, ctx_represenations, positive_idx_per_question, _ = self._encode_questions_and_passages()
+
+        logger.info("Av.rank validation: total q_vectors size=%s", q_represenations.size())
+        logger.info("Av.rank validation: total ctx_vectors size=%s", ctx_represenations.size())
+
+        q_num = q_represenations.size(0)
+        assert q_num == len(positive_idx_per_question)
+
+        sim_score_f = BiEncoderNllLoss.get_similarity_function()
+
+        scores = sim_score_f(q_represenations, ctx_represenations)
+        values, indices = torch.sort(scores, dim=1, descending=True)
+
+        rank = 0
+        for i, idx in enumerate(positive_idx_per_question):
+            # aggregate the rank of the known gold passage in the sorted results for each question
+            gold_idx = (indices[i] == idx).nonzero()
+            rank += gold_idx.item()
+
+        if self.distributed_factor > 1:
+            # each node calcuated its own rank, exchange the information between node and calculate the "global" average rank
+            # NOTE: the set of passages is still unique for every node
+            eval_stats = all_gather_list([rank, q_num], max_size=100)
+            for i, item in enumerate(eval_stats):
+                remote_rank, remote_q_num = item
+                if i != self.cfg.local_rank:
+                    rank += remote_rank
+                    q_num += remote_q_num
+
+        av_rank = float(rank / q_num)
+        logger.info("Av.rank validation: average rank %s, total questions=%d", av_rank, q_num)
+
+        return av_rank
+
+    def _encode_all_passages(self, all_passages: List[Tuple[object, BiEncoderPassage]]) -> List[Tuple[object, np.array]]:
+        encoded_passages: List[Tuple[object, np.array]] = gen_ctx_vectors(
+            self.cfg.train.val_av_rank_bsz, self.cfg.device, all_passages, self.biencoder.ctx_model, self.tensorizer
+        )
+        return encoded_passages
+
+    def _encode_questions_and_passages(self, without_negatives: bool = False, return_samples: bool = False):
+        q_represenations = []
+        ctx_represenations = []
+        positive_idx_per_question = []
+        all_samples: List[BiEncoderSample] = []
+
+        cfg = self.cfg
 
         if not self.dev_iterator:
             self.dev_iterator = self.get_data_iterator(
                 cfg.train.dev_batch_size, False, shuffle=False, rank=cfg.local_rank
             )
+
         data_iterator = self.dev_iterator
 
         sub_batch_size = cfg.train.val_av_rank_bsz
-        sim_score_f = BiEncoderNllLoss.get_similarity_function()
-        q_represenations = []
-        ctx_represenations = []
-        positive_idx_per_question = []
 
         num_hard_negatives = cfg.train.val_av_rank_hard_neg
         num_other_negatives = cfg.train.val_av_rank_other_neg
 
+        if without_negatives:
+            num_hard_negatives = 0
+            num_other_negatives = 0
+
         log_result_step = cfg.train.log_batch_step
+
         dataset = 0
         for i, samples_batch in enumerate(data_iterator.iterate_ds_data()):
             # samples += 1
-            if len(q_represenations) > cfg.train.val_av_rank_max_qs / distributed_factor:
+            if len(q_represenations) > cfg.train.val_av_rank_max_qs / self.distributed_factor:
                 break
 
             if isinstance(samples_batch, Tuple):
                 samples_batch, dataset = samples_batch
+
+            if return_samples:
+                all_samples.extend(samples_batch)
 
             biencoder_input = BiEncoder.create_biencoder_input2(
                 samples_batch,
@@ -399,8 +538,8 @@ class BiEncoderTrainer(object):
                     # otherwise the other input tensors will be split but only the first split will be called
                     continue
 
-                ctx_ids_batch = ctxs_ids[batch_start : batch_start + sub_batch_size]
-                ctx_seg_batch = ctxs_segments[batch_start : batch_start + sub_batch_size]
+                ctx_ids_batch = ctxs_ids[batch_start: batch_start + sub_batch_size]
+                ctx_seg_batch = ctxs_segments[batch_start: batch_start + sub_batch_size]
 
                 q_attn_mask = self.tensorizer.get_attn_mask(q_ids)
                 ctx_attn_mask = self.tensorizer.get_attn_mask(ctx_ids_batch)
@@ -431,39 +570,10 @@ class BiEncoderTrainer(object):
                     len(ctx_represenations),
                     len(q_represenations),
                 )
-
         ctx_represenations = torch.cat(ctx_represenations, dim=0)
         q_represenations = torch.cat(q_represenations, dim=0)
 
-        logger.info("Av.rank validation: total q_vectors size=%s", q_represenations.size())
-        logger.info("Av.rank validation: total ctx_vectors size=%s", ctx_represenations.size())
-
-        q_num = q_represenations.size(0)
-        assert q_num == len(positive_idx_per_question)
-
-        scores = sim_score_f(q_represenations, ctx_represenations)
-        values, indices = torch.sort(scores, dim=1, descending=True)
-
-        rank = 0
-        for i, idx in enumerate(positive_idx_per_question):
-            # aggregate the rank of the known gold passage in the sorted results for each question
-            gold_idx = (indices[i] == idx).nonzero()
-            rank += gold_idx.item()
-
-        if distributed_factor > 1:
-            # each node calcuated its own rank, exchange the information between node and calculate the "global" average rank
-            # NOTE: the set of passages is still unique for every node
-            eval_stats = all_gather_list([rank, q_num], max_size=100)
-            for i, item in enumerate(eval_stats):
-                remote_rank, remote_q_num = item
-                if i != cfg.local_rank:
-                    rank += remote_rank
-                    q_num += remote_q_num
-
-        av_rank = float(rank / q_num)
-        logger.info("Av.rank validation: average rank %s, total questions=%d", av_rank, q_num)
-
-        return av_rank
+        return q_represenations, ctx_represenations, positive_idx_per_question, all_samples
 
     def _train_epoch(
         self,
@@ -471,6 +581,7 @@ class BiEncoderTrainer(object):
         epoch: int,
         eval_step: int,
         train_data_iterator: MultiSetDataIterator,
+        all_passages: List[Tuple[object, BiEncoderPassage]],
     ) -> Dict[str, float]:
 
         cfg = self.cfg
@@ -583,11 +694,11 @@ class BiEncoderTrainer(object):
                     data_iteration,
                     epoch_batches,
                 )
-                self.validate_and_save(epoch, train_data_iterator.get_iteration(), scheduler, save=False)
+                self.validate_and_save(epoch, train_data_iterator.get_iteration(), scheduler, all_passages, save=False)
                 self.biencoder.train()
 
         logger.info("Epoch finished on %d", cfg.local_rank)
-        val_metrics: Dict[str, float] = self.validate_and_save(epoch, data_iteration, scheduler, save=True)
+        val_metrics: Dict[str, float] = self.validate_and_save(epoch, data_iteration, scheduler, all_passages, save=True)
 
         epoch_loss = (epoch_loss / epoch_batches) if epoch_batches > 0 else 0
         logger.info("Av Loss per epoch=%f", epoch_loss)
@@ -790,7 +901,9 @@ def main(cfg: DictConfig):
                entity="ask-ai",
                name=f"dpr_lr-{cfg.train.learning_rate}_bs-{cfg.train.batch_size}_"
                     f"{datetime.now().strftime('%Y%m%d_%H%M%S')}",
-               config=flatten_dict(cfg))
+               config=flatten_dict(cfg),
+               # mode="disabled"
+   )
 
     if cfg.train.gradient_accumulation_steps < 1:
         raise ValueError(

--- a/train_dense_encoder.py
+++ b/train_dense_encoder.py
@@ -367,7 +367,7 @@ class BiEncoderTrainer(object):
     def validate_ask_ai_metrics(self, all_passages: List[Tuple[object, BiEncoderPassage]]) -> Dict:
         logger.info("AskAI IR metrics")
 
-        encoded_passages_and_ids: List[Tuple[object, np.array]] = self._encode_all_passages(all_passages[0:100])
+        encoded_passages_and_ids: List[Tuple[object, np.array]] = self._encode_all_passages(all_passages)
         encoded_passages = torch.tensor([passage[1] for passage in encoded_passages_and_ids])
 
         q_represenations, _, positive_idx_per_question, all_samples = self._encode_questions_and_passages(

--- a/train_dense_encoder.py
+++ b/train_dense_encoder.py
@@ -387,6 +387,8 @@ class BiEncoderTrainer(object):
         scores = sim_score_f(q_represenations, encoded_passages)
         values, indices = torch.sort(scores, dim=1, descending=True)
 
+        indices = indices.tolist()
+
         ir_metrics: List[Dict] = []
         for index, sample in enumerate(all_samples):
             # for each question, get top k passages using their indices

--- a/train_dense_encoder.py
+++ b/train_dense_encoder.py
@@ -265,7 +265,7 @@ class BiEncoderTrainer(object):
         if not cfg.dev_datasets:
             validation_loss = 0
         else:
-            # metrics = self.validate_nll()
+            metrics = self.validate_nll()
             p_at_2 = None
             if all_passages:
                 ask_ai_ir_metrics = self.validate_ask_ai_metrics(all_passages)

--- a/train_dense_encoder.py
+++ b/train_dense_encoder.py
@@ -289,7 +289,7 @@ class BiEncoderTrainer(object):
             if (not cfg.train.higher_is_better and (
                     validation_loss < (self.best_validation_result or validation_loss + 1))) or (
                     cfg.train.higher_is_better and (
-                    validation_loss > (self.best_validation_result or validation_loss + 1))
+                    validation_loss > (self.best_validation_result or validation_loss - 1))
             ):
                 self.best_validation_result = validation_loss
                 self.best_cp_name = cp_name

--- a/train_dense_encoder.py
+++ b/train_dense_encoder.py
@@ -909,7 +909,7 @@ def main(cfg: DictConfig):
                name=f"dpr_lr-{cfg.train.learning_rate}_bs-{cfg.train.batch_size}_"
                     f"{datetime.now().strftime('%Y%m%d_%H%M%S')}",
                config=flatten_dict(cfg),
-               # mode="disabled"
+               mode="disabled" if not cfg.wandb_logs else None,
    )
 
     if cfg.train.gradient_accumulation_steps < 1:


### PR DESCRIPTION
This PR adds AskAI custom IR metrics to the training of DPR at the end of each epoch.

At the end of each epoch, it encodes all chunks and questions, build 2 matrices and apply a dot product between them in order to get the scores for each question and the list of passages (and limit to 1000).

We are now using p@2 as the metric for model selection.

Results: https://wandb.ai/ask-ai/dpr